### PR TITLE
Add script that queries the /r/nottheonion subreddit

### DIFF
--- a/scripts/nottheonion.coffee
+++ b/scripts/nottheonion.coffee
@@ -1,0 +1,15 @@
+# Description:
+#   Gets a headline from the /r/nottheonion subreddit
+#
+# Commands:
+#   hubot headline
+
+module.exports = (robot) ->
+
+  robot.respond /nottheonion/i, (msg) ->
+    msg.http('https://www.reddit.com/r/nottheonion/new.json?sort=new')
+      .get() (err, res, body) ->
+        urls = JSON.parse(body).data.children
+        index = Math.floor(Math.random() * urls.length)
+        msg.send urls[Object.keys(urls)[index]].data.title + " " + urls[Object.keys(urls)[index]].data.url
+


### PR DESCRIPTION
This PR adds a new script that queries a random headline from the [Not the onion](http://reddit.com/r/nottheonion) subreddit for weird news. I'm not sure how it will look in hipchat as the headline and the URL are just separated by a space.

Thoughts @smit1678 @drewbo ?
